### PR TITLE
Update README to fix OAuth term

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aws-lambda-authentication-nodejs
 
-This project is to demo how to create a Lambda function in Node.js which performs user authentication using oAuth Authorization Code grant type through AWS Cognito. The details, such as workflows and sequence diagrams can be found at [User authentication through authorization code grant type using AWS Cognito](https://dev.to/jinlianwang/user-authentication-through-authorization-code-grant-type-using-aws-cognito-1f93).
+This project is to demo how to create a Lambda function in Node.js which performs user authentication using OAuth Authorization Code grant type through AWS Cognito. The details, such as workflows and sequence diagrams can be found at [User authentication through authorization code grant type using AWS Cognito](https://dev.to/jinlianwang/user-authentication-through-authorization-code-grant-type-using-aws-cognito-1f93).
 
 The placeholder for this project is generated using AWS CLI. For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
 


### PR DESCRIPTION
## Summary
- fix case of OAuth in README description

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a9878628832bb38b74d830608d54