### PR TITLE
Persist sessions in DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ CORS_ALLOW_ORIGIN: http://<s3-bucket>.s3-website-us-east-1.amazonaws.com
 
 A redeployment of API Gateway and Lambda functions are necessary after the change, see [template.yml](https://github.com/JinlianWang/aws-lambda-authentication-nodejs/blob/master/template.yml) for details.
 
+## Session Persistence
+
+Session information is now stored in a DynamoDB table. The name of the table is
+provided through the `SESSION_TABLE` environment variable and created as part of
+the SAM stack. Persisting sessions allows them to survive multiple Lambda
+invocations and enables horizontal scaling.
+
 ## Deploy the application
 
 To build and deploy your application, run the following in your shell to create a S3 bucket: 

--- a/src/handlers/authentication-handler.js
+++ b/src/handlers/authentication-handler.js
@@ -20,10 +20,10 @@ exports.authenticationHandler = async (event) => {
             response = authenticationService.loginUrl(authenticationService.getGatewayUrl(event));
             break;
         case "/apis/authentication/status":
-            response = authenticationService.loginStatus(event.headers && event.headers["Authorization"]);
+            response = await authenticationService.loginStatus(event.headers && event.headers["Authorization"]);
             break;
         case "/apis/authentication/logout":
-            response = authenticationService.logout(event.headers && event.headers["Authorization"]);
+            response = await authenticationService.logout(event.headers && event.headers["Authorization"]);
             break;
         case "/apis/authentication/exchange":
             const code = event.queryStringParameters && event.queryStringParameters["code"];

--- a/template.yml
+++ b/template.yml
@@ -21,6 +21,7 @@ Globals:
         #CORS_ALLOW_ORIGIN: http://oauthdemo2021.s3-website-us-east-1.amazonaws.com
         LOGIN_REDIRECT_URL: http://localhost:4200
         #LOGIN_REDIRECT_URL: http://oauthdemo2021.s3-website-us-east-1.amazonaws.com
+        SESSION_TABLE: !Ref SessionTable
   Api:
     Cors:
       AllowMethods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
@@ -39,12 +40,24 @@ Resources:
         - AWSLambda_ReadOnlyAccess
         - AWSXrayWriteOnlyAccess
         - AWSLambdaVPCAccessExecutionRole
+        - AmazonDynamoDBFullAccess
       Events:
         DemoAPI:
           Type: Api
           Properties:
             Path: /{proxy+}
             Method: any
+
+  SessionTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
 
 Outputs:
   WebEndpoint:


### PR DESCRIPTION
## Summary
- persist session data using DynamoDB
- update handler to await new async methods
- expose session table and permissions in SAM template
- document session persistence

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ff685dac832b954343b1235fa566