### PR TITLE
Implement token revocation on logout

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -41,6 +41,11 @@ Resources:
         - AWSXrayWriteOnlyAccess
         - AWSLambdaVPCAccessExecutionRole
         - AmazonDynamoDBFullAccess
+        - Statement:
+            Effect: Allow
+            Action:
+              - cognito-idp:GlobalSignOut
+            Resource: "*"
       Events:
         DemoAPI:
           Type: Api


### PR DESCRIPTION
## Summary
- store tokens in session when exchanging the auth code
- revoke Cognito session during logout
- allow function to call `cognito-idp:GlobalSignOut`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852aabfc6dc832bbc010c4a6badbc43